### PR TITLE
feat(skill): add OpenClaw support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ Apple-authored SwiftUI and Apple platform guidance, packaged as skills for AI co
 
 ## What is this?
 
-SwiftUI is opinionated. Most AI agents don't know those opinions.
+SwiftUI is opinionated. Most AI agents do not know those opinions.
 
-/swiftui-skills extracts internal Apple documentation shipped inside Xcode and turns it into reusable skills that help AI agents write idiomatic, Apple-native SwiftUI code.
+`/swiftui-skills` extracts internal Apple documentation shipped inside Xcode and turns it into reusable skills that help AI agents write idiomatic, Apple-native SwiftUI code.
 
 - Uses Apple-written guidance from inside Xcode
 - Reduces hallucinated or non-idiomatic SwiftUI
-- Works with Claude Code, Cursor, and similar tools
+- Works with Claude Code, Cursor, Codex, OpenClaw, and similar tools
 - Open source and local-first
 
 ## Installation
@@ -21,33 +21,58 @@ SwiftUI is opinionated. Most AI agents don't know those opinions.
 curl -fsSL https://swiftui-skills.ameyalambat.com/install | bash
 ```
 
-### Advanced: Using npx skills
+The installer extracts local Xcode docs and installs the skill into detected runtimes, including OpenClaw shared installs at `~/.openclaw/skills/swiftui-skills`.
+
+### Using `npx skills`
 
 ```bash
 npx skills add ameyalambat128/swiftui-skills
 ```
 
-Choose the install scope in the `skills` TUI, and keep `Symlink (Recommended)` selected.
+Choose the install scope in the `skills` TUI and keep `Symlink (Recommended)` selected.
 
-#### Global install
+#### Shared agent install
 
 ```bash
 ~/.agents/skills/swiftui-skills/setup.sh
 ```
 
-#### Project-local install
+#### Project-local agent install
 
 ```bash
 ./.agents/skills/swiftui-skills/setup.sh
 ```
 
-The first command installs the skill. The setup command extracts Apple documentation from your local Xcode installation.
-Agent-specific placement like Claude Code is handled by the `skills` CLI, so no extra Claude-specific step is needed in the interactive flow.
+### OpenClaw manual install
+
+OpenClaw can load the same canonical skill package from any of these paths:
+
+- `~/.agents/skills/swiftui-skills`
+- `~/.openclaw/skills/swiftui-skills`
+- `<workspace>/skills/swiftui-skills`
+
+For a shared OpenClaw install:
+
+```bash
+mkdir -p ~/.openclaw/skills
+cp -R src/skill ~/.openclaw/skills/swiftui-skills
+~/.openclaw/skills/swiftui-skills/setup.sh
+```
+
+For a workspace-local OpenClaw install:
+
+```bash
+mkdir -p ./skills
+cp -R src/skill ./skills/swiftui-skills
+./skills/swiftui-skills/setup.sh
+```
+
+After setup, start a new OpenClaw session or restart the gateway.
 
 ### Requirements
 
 - macOS
-- Xcode 26 or later (the documentation lives inside Xcode)
+- Xcode 26 or later
 
 ### Custom paths
 
@@ -63,11 +88,24 @@ If Xcode is installed in a non-standard location:
 
 ## How it works
 
-1. The installer extracts Apple documentation from your local Xcode install
-2. Skills define how agents should use that documentation
-3. Your AI agent uses the docs as source of truth when writing code
+1. The installer extracts Apple documentation from your local Xcode install.
+2. The skill tells the agent how to use that documentation during generation and review.
+3. Your agent uses the extracted docs as source of truth when writing SwiftUI code.
 
-No Apple documentation is redistributed. Everything is extracted locally on install.
+No Apple documentation is redistributed. Everything is extracted locally during setup.
+
+## What "supports OpenClaw" means
+
+This project is still a developer-focused SwiftUI skill.
+
+OpenClaw support means:
+
+- The canonical `SKILL.md` is compatible with OpenClaw skill loading.
+- The same skill package can live in OpenClaw-visible paths like `~/.agents/skills`, `~/.openclaw/skills`, or `<workspace>/skills`.
+- OpenClaw users get the same local-docs workflow after running `setup.sh`.
+- OpenClaw users can verify the skill with native commands like `openclaw skills list`.
+
+This does not add a plugin, split the package, or change the product into an OpenClaw-only tool.
 
 ## What's included
 
@@ -86,40 +124,60 @@ Documentation extracted from Xcode covers:
 
 ## Usage
 
-### Claude Code
+### Claude Code and similar agents
 
-The custom installer automatically links the skill to `~/.claude/skills/` when Claude Code is detected. The skill is available immediately.
+The installer can place the skill directly into detected agent paths like `~/.claude/skills`, `~/.codex/skills`, and related runtimes.
 
-### Cursor
+### OpenClaw
 
-Add the skill path to your Cursor configuration:
+OpenClaw already loads visible skills from these paths, in precedence order:
 
+1. `<workspace>/skills`
+2. `<workspace>/.agents/skills`
+3. `~/.agents/skills`
+4. `~/.openclaw/skills`
+
+To verify the skill is visible:
+
+```bash
+openclaw skills list
 ```
-~/.swiftui-skills/
+
+Then start a new session and try a representative SwiftUI task:
+
+```bash
+openclaw agent --message "Build a SwiftUI settings screen with a toolbar and explain which local docs you used."
 ```
+
+Expected smoke-test behavior:
+
+- The skill is listed by OpenClaw.
+- The agent references local extracted docs instead of inventing APIs.
+- If `docs/` is empty, the agent tells you to run `setup.sh` before proceeding.
 
 ## Project structure
 
-```
+```text
 swiftui-skills/
 ├── src/
 │   ├── app/                    # Next.js website
 │   ├── skill/                  # Skill package
-│   │   ├── skill.md            # Agent contract
-│   │   ├── manifest.json       # Tool compatibility
-│   │   ├── prompts/            # System, router, reviewer, generator, refactorer
-│   │   └── docs/               # Populated by installer
+│   │   ├── SKILL.md           # Canonical skill contract
+│   │   ├── manifest.json      # Tool compatibility helpers
+│   │   ├── prompts/           # System, router, reviewer, generator, refactorer
+│   │   ├── docs/              # Populated by setup
+│   │   └── setup.sh           # Local Xcode docs extraction
 │   └── scripts/
 │       ├── install.sh
 │       └── uninstall.sh
 └── public/
-    └── install                 # curl target
+    └── install                # curl target
 ```
 
 ## Uninstall
 
 ```bash
-~/.swiftui-skills/scripts/uninstall.sh
+bash src/scripts/uninstall.sh
 ```
 
 ## Who this is for

--- a/src/app/api/github-stars/route.ts
+++ b/src/app/api/github-stars/route.ts
@@ -7,9 +7,7 @@ const cacheControlHeader = "s-maxage=3600, stale-while-revalidate=300";
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const owner =
-    searchParams.get("username") ||
-    searchParams.get("owner") ||
-    defaultOwner;
+    searchParams.get("username") || searchParams.get("owner") || defaultOwner;
   const repo = searchParams.get("repo") || defaultRepo;
 
   const headers: HeadersInit = {
@@ -22,29 +20,33 @@ export async function GET(request: Request) {
   }
 
   try {
-    const response = await fetch(`https://api.github.com/repos/${owner}/${repo}`, {
-      headers,
-      next: { revalidate: 3600 },
-    });
+    const response = await fetch(
+      `https://api.github.com/repos/${owner}/${repo}`,
+      {
+        headers,
+        next: { revalidate: 3600 },
+      },
+    );
 
     if (!response.ok) {
       return NextResponse.json(
         { stars: 0 },
-        { status: 200, headers: { "Cache-Control": cacheControlHeader } }
+        { status: 200, headers: { "Cache-Control": cacheControlHeader } },
       );
     }
 
     const data = (await response.json()) as { stargazers_count?: number };
-    const stars = typeof data.stargazers_count === "number" ? data.stargazers_count : 0;
+    const stars =
+      typeof data.stargazers_count === "number" ? data.stargazers_count : 0;
 
     return NextResponse.json(
       { stars },
-      { status: 200, headers: { "Cache-Control": cacheControlHeader } }
+      { status: 200, headers: { "Cache-Control": cacheControlHeader } },
     );
   } catch {
     return NextResponse.json(
       { stars: 0 },
-      { status: 200, headers: { "Cache-Control": cacheControlHeader } }
+      { status: 200, headers: { "Cache-Control": cacheControlHeader } },
     );
   }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -85,6 +85,12 @@ const faqItems = [
       "Yes. The same SwiftUI Skills setup for Cursor uses locally extracted documentation and skill prompts to improve SwiftUI output inside your editor. The goal is the same across tools: better SwiftUI structure, fewer hallucinated APIs, and behavior that stays closer to Apple-native patterns.",
   },
   {
+    value: "openclaw",
+    question: "Does SwiftUI Skills support OpenClaw?",
+    answer:
+      "Yes. SwiftUI Skills now supports OpenClaw as an additional runtime. The same canonical skill package can live in OpenClaw-visible paths like ~/.agents/skills, ~/.openclaw/skills, or a workspace skills folder, and it keeps the same local Xcode docs workflow after setup.",
+  },
+  {
     value: "xcode-docs",
     question: "Why is this a SwiftUI coding skill from Xcode docs?",
     answer:
@@ -99,9 +105,12 @@ function Divider() {
 export default function Home() {
   const npxCommand = "npx skills add ameyalambat128/swiftui-skills";
   const globalSetupCommand = "~/.agents/skills/swiftui-skills/setup.sh";
+  const openClawSetupCommand = "~/.openclaw/skills/swiftui-skills/setup.sh";
+  const openClawWorkspaceCommand = "./skills/swiftui-skills/setup.sh";
   const localSetupCommand = "./.agents/skills/swiftui-skills/setup.sh";
   const curlCommand =
     "curl -fsSL https://swiftui-skills.ameyalambat.com/install | bash";
+  const openClawListCommand = "openclaw skills list";
 
   return (
     <div className="relative min-h-screen overflow-x-hidden">
@@ -131,6 +140,9 @@ export default function Home() {
             SwiftUI Skills extracts Apple-authored documentation shipped inside
             Xcode and turns it into reusable skills that help AI agents write
             idiomatic, Apple-native SwiftUI.
+          </p>
+          <p className="mt-4 text-sm text-gray-500">
+            Now supports OpenClaw as well, with the same local-docs workflow.
           </p>
 
           {/* Installation */}
@@ -175,6 +187,18 @@ export default function Home() {
               </div>
               <div>
                 <p className="text-xs text-gray-500 mb-2 font-sans">
+                  OpenClaw shared install
+                </p>
+                <div className="flex gap-4 justify-between items-center">
+                  <div className="text-gray-400 overflow-x-auto">
+                    <span className="select-none text-gray-600">$ </span>
+                    {openClawSetupCommand}
+                  </div>
+                  <CopyButton text={openClawSetupCommand} />
+                </div>
+              </div>
+              <div>
+                <p className="text-xs text-gray-500 mb-2 font-sans">
                   Project-local install
                 </p>
                 <div className="flex gap-4 justify-between items-center">
@@ -183,6 +207,18 @@ export default function Home() {
                     {localSetupCommand}
                   </div>
                   <CopyButton text={localSetupCommand} />
+                </div>
+              </div>
+              <div>
+                <p className="text-xs text-gray-500 mb-2 font-sans">
+                  OpenClaw workspace install
+                </p>
+                <div className="flex gap-4 justify-between items-center">
+                  <div className="text-gray-400 overflow-x-auto">
+                    <span className="select-none text-gray-600">$ </span>
+                    {openClawWorkspaceCommand}
+                  </div>
+                  <CopyButton text={openClawWorkspaceCommand} />
                 </div>
               </div>
             </div>
@@ -222,6 +258,15 @@ export default function Home() {
               className="text-gray-400 underline hover:text-white"
             >
               Codex
+            </Link>
+            ,{" "}
+            <Link
+              href="https://docs.openclaw.ai/tools/skills"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-gray-400 underline hover:text-white"
+            >
+              OpenClaw
             </Link>
             ,{" "}
             <Link
@@ -276,6 +321,39 @@ export default function Home() {
 
         {/* Main Content */}
         <main className="space-y-12">
+          <section>
+            <h2 className="mb-4 text-xl font-bold gradient-text">
+              OpenClaw support
+            </h2>
+            <p className="mb-4 leading-relaxed text-gray-400">
+              SwiftUI Skills remains a developer-focused SwiftUI skill. OpenClaw
+              support is additive: same package, same local-docs workflow, one
+              more runtime.
+            </p>
+            <p className="mb-4 leading-relaxed text-gray-400">
+              OpenClaw can load the skill from shared agent installs, OpenClaw
+              shared installs, or workspace-local `skills/` folders.
+            </p>
+            <div className="rounded-2xl border border-neutral-800 bg-neutral-950/60 p-5 ring-1 ring-neutral-900">
+              <p className="text-xs uppercase tracking-[0.22em] text-gray-500">
+                Verify in OpenClaw
+              </p>
+              <div className="mt-3 flex gap-4 justify-between items-center">
+                <div className="text-sm font-mono text-gray-400 overflow-x-auto">
+                  <span className="select-none text-gray-600">$ </span>
+                  {openClawListCommand}
+                </div>
+                <CopyButton text={openClawListCommand} />
+              </div>
+              <p className="mt-3 text-sm leading-relaxed text-gray-500">
+                Start a new session after setup, then ask for a SwiftUI task and
+                confirm the agent grounds itself in local extracted docs.
+              </p>
+            </div>
+          </section>
+
+          <Divider />
+
           <section>
             <h2 className="mb-4 text-xl font-bold gradient-text">
               What is SwiftUI Skills?
@@ -457,8 +535,8 @@ export default function Home() {
             </h2>
             <p className="mb-6 max-w-2xl leading-relaxed text-gray-400">
               A short reference for teams looking for SwiftUI Skills and a
-              better setup for AI coding agents, including Claude Code and
-              Cursor.
+              better setup for AI coding agents, including Claude Code,
+              OpenClaw, and Cursor.
             </p>
             <div className="rounded-2xl border border-neutral-800 bg-neutral-950/60 px-5 py-3 ring-1 ring-neutral-900">
               <Accordion type="single" collapsible className="w-full">

--- a/src/components/background/background.module.css
+++ b/src/components/background/background.module.css
@@ -40,17 +40,14 @@
   z-index: 3;
   width: 100%;
   max-width: 640px;
-  background-image: radial-gradient(
-      at 27% 37%,
-      hsla(215, 98%, 61%, 1) 0px,
-      transparent 0%
-    ),
+  background-image:
+    radial-gradient(at 27% 37%, hsla(215, 98%, 61%, 1) 0px, transparent 0%),
     /* radial-gradient(at 97% 21%, hsla(125, 98%, 72%, 1) 0px, transparent 50%), */
-      /* radial-gradient(at 52% 99%, hsla(354, 98%, 61%, 1) 0px, transparent 50%),
+    /* radial-gradient(at 52% 99%, hsla(354, 98%, 61%, 1) 0px, transparent 50%),
     radial-gradient(at 10% 29%, hsla(256, 96%, 67%, 1) 0px, transparent 50%),
     radial-gradient(at 97% 96%, hsla(38, 60%, 74%, 1) 0px, transparent 50%),
     radial-gradient(at 33% 50%, hsla(222, 67%, 73%, 1) 0px, transparent 50%), */
-      /* radial-gradient(at 79% 53%, hsla(343, 68%, 79%, 1) 0px, transparent 10%); */;
+    /* radial-gradient(at 79% 53%, hsla(343, 68%, 79%, 1) 0px, transparent 10%); */;
   position: absolute;
   content: "";
   width: 100%;

--- a/src/components/github-stars.tsx
+++ b/src/components/github-stars.tsx
@@ -6,19 +6,13 @@ import { GitHubIcon, StarIcon } from "@/components/icons";
 
 async function fetchGitHubStars(username: string, repo: string) {
   const response = await fetch(
-    `/api/github-stars?username=${username}&repo=${repo}`
+    `/api/github-stars?username=${username}&repo=${repo}`,
   );
   const data = (await response.json()) as { stars: number };
   return data.stars;
 }
 
-function GitHubStars({
-  username,
-  repo,
-}: {
-  username: string;
-  repo: string;
-}) {
+function GitHubStars({ username, repo }: { username: string; repo: string }) {
   const { data: stars } = useQuery({
     queryKey: ["github-stars", username, repo],
     queryFn: () => fetchGitHubStars(username, repo),

--- a/src/components/providers.tsx
+++ b/src/components/providers.tsx
@@ -13,7 +13,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
             refetchOnWindowFocus: false,
           },
         },
-      })
+      }),
   );
 
   return (

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,6 @@
-import { clsx, type ClassValue } from "clsx"
-import { twMerge } from "tailwind-merge"
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+  return twMerge(clsx(inputs));
 }

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -301,6 +301,9 @@ fi
 if [ -d "$HOME/.codex" ]; then
     DETECTED_AGENTS+=("Codex")
 fi
+if command -v openclaw >/dev/null 2>&1 || [ -d "$HOME/.openclaw" ]; then
+    DETECTED_AGENTS+=("OpenClaw")
+fi
 if command -v opencode >/dev/null 2>&1 || [ -d "$HOME/.config/opencode" ]; then
     DETECTED_AGENTS+=("OpenCode")
 fi
@@ -350,6 +353,14 @@ if [ -d "$HOME/.codex" ]; then
     INSTALLED_PATHS+=("~/.codex/skills/$SKILL_NAME")
 fi
 
+if command -v openclaw >/dev/null 2>&1 || [ -d "$HOME/.openclaw" ]; then
+    OPENCLAW_DIR="$HOME/.openclaw/skills/$SKILL_NAME"
+    rm -rf "$OPENCLAW_DIR"
+    mkdir -p "$OPENCLAW_DIR"
+    cp -R "$TMP_DIR/"* "$OPENCLAW_DIR/"
+    INSTALLED_PATHS+=("~/.openclaw/skills/$SKILL_NAME")
+fi
+
 if command -v opencode >/dev/null 2>&1 || [ -d "$HOME/.config/opencode" ]; then
     OPENCODE_DIR="$HOME/.config/opencode/skill/$SKILL_NAME"
     rm -rf "$OPENCODE_DIR"
@@ -388,7 +399,8 @@ echo "│                                                                   │"
 
 if [ ${#INSTALLED_PATHS[@]} -eq 0 ]; then
     echo "│  No agents detected. Install an agent first:                      │"
-    echo "│  Claude Code, Cursor, Codex, OpenCode, Windsurf, or Gemini CLI    │"
+    echo "│  Claude Code, Cursor, Codex, OpenClaw, OpenCode, Windsurf, or     │"
+    echo "│  Gemini CLI                                                       │"
 else
     for path in "${INSTALLED_PATHS[@]}"; do
         printf "│  ${GREEN}✓${NC} %-60s │\n" "$path"

--- a/src/scripts/uninstall.sh
+++ b/src/scripts/uninstall.sh
@@ -43,6 +43,14 @@ if [ -d "$CODEX_DIR" ]; then
     TOOLS_REMOVED=$((TOOLS_REMOVED + 1))
 fi
 
+# Remove from OpenClaw
+OPENCLAW_DIR="$HOME/.openclaw/skills/$SKILL_NAME"
+if [ -d "$OPENCLAW_DIR" ]; then
+    rm -rf "$OPENCLAW_DIR"
+    print_success "OpenClaw: removed"
+    TOOLS_REMOVED=$((TOOLS_REMOVED + 1))
+fi
+
 # Remove from OpenCode
 OPENCODE_DIR="$HOME/.config/opencode/skill/$SKILL_NAME"
 if [ -d "$OPENCODE_DIR" ]; then

--- a/src/skill/SKILL.md
+++ b/src/skill/SKILL.md
@@ -1,18 +1,18 @@
 ---
-name: swiftui-skills
+name: swiftui_skills
 description: Apple-authored SwiftUI and platform guidance extracted from Xcode. Helps AI agents write idiomatic, Apple-native SwiftUI with reduced hallucinations.
-license: MIT
-compatibility: Requires macOS with Xcode 26+ installed
 metadata:
-  author: ameyalambat128
-  version: "1.0"
+  openclaw:
+    os: ["darwin"]
+    requires:
+      bins: ["xcodebuild"]
 ---
 
 # swiftui-skills
 
 ## What this is
 
-A packaged set of Apple-authored AdditionalDocumentation shipped inside Xcode, plus prompts that enforce Apple-native patterns and reduce hallucinations.
+A packaged set of Apple-authored AdditionalDocumentation shipped inside Xcode, plus prompts that enforce Apple-native patterns and reduce hallucinations for developer-focused coding workflows.
 
 ## Source of truth
 
@@ -27,13 +27,19 @@ All factual claims and APIs must be grounded in files under `/docs`.
 ## Setup check
 
 If the `docs/` folder is empty or contains no `.md` files, the Xcode documentation has not been extracted yet.
-Tell the user to run the setup script that matches their `npx skills` install scope:
+Tell the user to run the setup script from the installed skill directory:
 
 ```
-# Global install
+# Shared agent install
 ~/.agents/skills/swiftui-skills/setup.sh
 
-# Project-local install
+# OpenClaw shared install
+~/.openclaw/skills/swiftui-skills/setup.sh
+
+# OpenClaw workspace install
+./skills/swiftui-skills/setup.sh
+
+# Project-local agent install
 ./.agents/skills/swiftui-skills/setup.sh
 ```
 

--- a/src/skill/prompts/generator.md
+++ b/src/skill/prompts/generator.md
@@ -1,4 +1,5 @@
 Generate code that:
+
 - Is minimal and idiomatic.
 - Includes required imports and plist keys when relevant.
 - Includes a small usage example or preview if applicable.

--- a/src/skill/prompts/refactorer.md
+++ b/src/skill/prompts/refactorer.md
@@ -1,4 +1,5 @@
 Refactor approach:
+
 - Preserve behavior.
 - Do minimal diff first, then improvements.
 - Provide stepwise migration instructions.

--- a/src/skill/prompts/reviewer.md
+++ b/src/skill/prompts/reviewer.md
@@ -1,4 +1,5 @@
 Review checklist (cite docs used):
+
 - Correct framework usage (types, methods, property names)
 - Availability and platform constraints
 - State and data flow, minimal surface area
@@ -7,6 +8,7 @@ Review checklist (cite docs used):
 - Clean Swift style, minimal diff when refactoring
 
 Return:
+
 - Issues: Blockers / Major / Minor
 - Suggested patch plan
 - Optional: a cleaned-up code version

--- a/src/skill/prompts/router.md
+++ b/src/skill/prompts/router.md
@@ -1,10 +1,12 @@
 Routing table:
 
 AlarmKit:
+
 - Keywords: AlarmKit, AlarmManager, schedule, countdown, NSAlarmKitUsageDescription
 - Use: docs/SwiftUI-AlarmKit-Integration.md
 
 Liquid Glass:
+
 - Keywords: glassEffect, GlassEffectContainer, UIGlassEffect, widgetRenderingMode
 - Use:
   - SwiftUI: docs/SwiftUI-Implementing-Liquid-Glass-Design.md
@@ -13,25 +15,31 @@ Liquid Glass:
   - AppKit: docs/AppKit-Implementing-Liquid-Glass-Design.md
 
 WebKit in SwiftUI:
+
 - Keywords: WebView, WebPage, callJavaScript, NavigationDeciding
 - Use: docs/SwiftUI-WebKit-Integration.md
 
 SwiftData inheritance:
+
 - Keywords: @Model, subclass, base class, #Predicate, "is" filtering
 - Use: docs/SwiftData-Class-Inheritance.md
 
 Swift performance primitives:
+
 - Keywords: InlineArray, Span, MutableSpan
 - Use: docs/Swift-InlineArray-Span.md
 
 SwiftUI toolbar:
+
 - Keywords: toolbar(id:), ToolbarItem(id:), DefaultToolbarItem, searchToolbarBehavior
 - Use: docs/SwiftUI-New-Toolbar-Features.md
 
 Styled text editing:
+
 - Keywords: AttributedString, TextEditor(text:selection:), AttributedTextSelection
 - Use: docs/SwiftUI-Styled-Text-Editing.md
 
 visionOS widgets:
+
 - Keywords: supportedMountingStyles, widgetTexture, levelOfDetail, systemExtraLargePortrait
 - Use: docs/Widgets-for-visionOS.md

--- a/src/skill/prompts/system.md
+++ b/src/skill/prompts/system.md
@@ -4,6 +4,7 @@ You MUST use the documentation in /docs as source of truth.
 Before coding, select the minimal set of relevant docs, then follow their patterns.
 
 Rules:
+
 - No invented APIs or types.
 - Prefer idiomatic SwiftUI composition and correct concurrency.
 - Provide compile-ready Swift unless user asks otherwise.


### PR DESCRIPTION
## Summary
- Add first-class OpenClaw compatibility to the SwiftUI skill package without changing the core developer-focused product.
- Extend install and uninstall flows so shared OpenClaw skill installs work alongside existing agent runtimes.
- Update README and landing page copy to explain what OpenClaw support means, how to install it, and how to verify it.

## Changes
- **Skill packaging**: Make the canonical `SKILL.md` OpenClaw-safe, add minimal OpenClaw gating metadata, and keep the same local Xcode docs workflow.
- **Installer support**: Detect OpenClaw in the shell installer and install or remove the skill from `~/.openclaw/skills` in addition to existing runtimes.
- **Docs and site**: Add OpenClaw as a supported runtime in the README and landing page, document shared and workspace install paths, and include a manual smoke test using `openclaw skills list`.
- **Formatting**: Normalize repo formatting in files touched by the required format pass.

## Testing
- [ ] Run `bun run check`
- [ ] Install into `~/.openclaw/skills/swiftui-skills` and verify `openclaw skills list` shows the skill
- [ ] Install into `<workspace>/skills/swiftui-skills` and verify OpenClaw prefers the workspace copy
- [ ] Confirm a SwiftUI prompt references local extracted docs, or asks to run `setup.sh` when `docs/` is empty

## Notes
No breaking changes intended. OpenClaw support is additive and keeps the existing cross-agent positioning.