### PR TITLE
fix(skill): normalize canonical swiftui-skills name

### DIFF
--- a/src/skill/SKILL.md
+++ b/src/skill/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: swiftui_skills
+name: swiftui-skills
 description: Apple-authored SwiftUI and platform guidance extracted from Xcode. Helps AI agents write idiomatic, Apple-native SwiftUI with reduced hallucinations.
 metadata:
   openclaw:


### PR DESCRIPTION
## Summary
- Normalize the skill frontmatter name to `swiftui-skills` so it matches package, manifest, and installer metadata
- Prevent install tracking from splitting between `swiftui-skills` and `swiftui_skills`
- Keep future installs aligned under one canonical skill identifier

## Changes
- **Skill metadata**: Update `src/skill/SKILL.md` frontmatter from `swiftui_skills` to `swiftui-skills`
- **Install consistency**: Align the runtime-visible skill name with the existing installer and manifest naming used across the repo

## Testing
- [ ] Verify fresh install shows only `swiftui-skills` in skill listings
- [ ] Verify install counts no longer fragment across hyphen and underscore variants
- [ ] Verify `~/.agents/skills/swiftui-skills/setup.sh` still works after install

## Notes
No breaking changes. This PR only normalizes metadata for a single existing skill.
